### PR TITLE
Add 'onlyOutputJson' flag as a dryrun. 

### DIFF
--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DefaultFileUploader.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DefaultFileUploader.java
@@ -21,6 +21,7 @@ public class DefaultFileUploader implements FileUploader {
   private Path prefix;
   private Path outputFile;
   private Log log;
+  private boolean onlyOutputJson;
 
   @Override
   public void init(UploadConfiguration config, Log log) {
@@ -28,6 +29,7 @@ public class DefaultFileUploader implements FileUploader {
     this.s3Artifacts = Collections.synchronizedSet(new LinkedHashSet<S3Artifact>());
     this.prefix = config.getPrefix();
     this.outputFile = config.getOutputFile();
+    this.onlyOutputJson = config.isOnlyOutputJson();
     this.log = log;
   }
 
@@ -51,11 +53,13 @@ public class DefaultFileUploader implements FileUploader {
     }
 
     Path localPath = artifact.getLocalPath();
-    if (keyExists(config.getS3Bucket(), s3Key)) {
-      log.info("Key already exists " + s3Key);
-    } else {
-      doUpload(config.getS3Bucket(), s3Key, localPath);
-      log.info("Successfully uploaded key " + s3Key);
+    if (!onlyOutputJson) {
+      if (keyExists(config.getS3Bucket(), s3Key)) {
+        log.info("Key already exists " + s3Key);
+      } else {
+        doUpload(config.getS3Bucket(), s3Key, localPath);
+        log.info("Successfully uploaded key " + s3Key);
+      }
     }
 
     String targetPath = prefix.resolve(artifact.getTargetPath()).toString();

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadConfiguration.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadConfiguration.java
@@ -14,6 +14,7 @@ public class UploadConfiguration {
   private final String s3SecretKey;
   private final Path outputFile;
   private final boolean allowUnresolvedSnapshots;
+  private final boolean onlyOutputJson;
 
   public UploadConfiguration(Path prefix,
                              String s3Bucket,
@@ -21,7 +22,8 @@ public class UploadConfiguration {
                              String s3AccessKey,
                              String s3SecretKey,
                              Path outputFile,
-                             boolean allowUnresolvedSnapshots) {
+                             boolean allowUnresolvedSnapshots,
+                             boolean onlyOutputJson) {
     this.prefix = prefix;
     this.s3Bucket = s3Bucket;
     this.s3ArtifactRoot = s3ArtifactRoot;
@@ -29,6 +31,7 @@ public class UploadConfiguration {
     this.s3SecretKey = s3SecretKey;
     this.outputFile = outputFile;
     this.allowUnresolvedSnapshots = allowUnresolvedSnapshots;
+    this.onlyOutputJson = onlyOutputJson;
   }
 
   public S3Service newS3Service() {
@@ -62,5 +65,9 @@ public class UploadConfiguration {
 
   public boolean isAllowUnresolvedSnapshots() {
     return allowUnresolvedSnapshots;
+  }
+
+  public boolean isOnlyOutputJson() {
+    return onlyOutputJson;
   }
 }

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadJarsMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadJarsMojo.java
@@ -67,6 +67,9 @@ public class UploadJarsMojo extends AbstractMojo {
   @Parameter(property = "slimfast.allowUnresolvedSnapshots", defaultValue = "false")
   private boolean allowUnresolvedSnapshots;
 
+  @Parameter(property = "slimfast.onlyOutputJson", defaultValue = "false")
+  private boolean onlyOutputJson;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (skip) {
@@ -128,7 +131,8 @@ public class UploadJarsMojo extends AbstractMojo {
         s3AccessKey,
         s3SecretKey,
         Paths.get(outputFile),
-        allowUnresolvedSnapshots
+        allowUnresolvedSnapshots,
+        onlyOutputJson
     );
   }
 


### PR DESCRIPTION
When set, the upload goal does not upload to S3, but rather only outputs the json manifest.

To address a usecase we have where we want to package the json manifest back into the jar, so we run the dryrun upload goal during the package phase.