### PR TITLE
Aws sdk 1.11.461

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,9 @@
   </prerequisites>
 
   <properties>
-    <aws.sdk.version>1.11.98</aws.sdk.version>
+    <aws.sdk.version>1.11.461</aws.sdk.version>
+    <dep.httpclient.version>4.5.5</dep.httpclient.version>
+    <dep.httpcore.version>4.4.9</dep.httpcore.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This fixes compatibility when running maven using JDK11. I tested this on a branch of an internal service.

@jhaber @kmclarnon 