### PR TITLE
Use multipart uploads for large JARs

### DIFF
--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DefaultFileUploader.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DefaultFileUploader.java
@@ -1,6 +1,8 @@
 package com.hubspot.maven.plugins.slimfast;
 
 import java.nio.file.Path;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -10,14 +12,24 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkBaseException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.amazonaws.services.s3.transfer.Upload;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 public class DefaultFileUploader extends BaseFileUploader {
   private AmazonS3 s3Service;
+  private TransferManager transferManager;
   private Log log;
 
   @Override
   protected void doInit(UploadConfiguration config, Log log) {
     this.s3Service = S3Factory.create(config.getS3AccessKey(), config.getS3SecretKey());
+    ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("slimfast-upload").setDaemon(true).build();
+    transferManager = TransferManagerBuilder.standard()
+        .withS3Client(s3Service)
+        .withExecutorFactory(() -> Executors.newFixedThreadPool(config.getUploadThreads(), threadFactory))
+        .build();
     this.log = log;
   }
 
@@ -29,9 +41,10 @@ public class DefaultFileUploader extends BaseFileUploader {
     }
 
     try {
-      s3Service.putObject(bucket, key, path.toFile());
+      Upload upload = transferManager.upload(bucket, key, path.toFile());
+      upload.waitForUploadResult();
       log.info("Successfully uploaded key " + key);
-    } catch (SdkClientException e) {
+    } catch (SdkClientException | InterruptedException e) {
       throw new MojoFailureException("Error uploading file " + path, e);
     }
   }

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DownloadJarsMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DownloadJarsMojo.java
@@ -34,6 +34,9 @@ public class DownloadJarsMojo extends AbstractMojo {
   @Parameter(property = "slimfast.s3.secretKey", defaultValue = "${s3.secret.key}", required = true)
   private String s3SecretKey;
 
+  @Parameter(property = "slimfast.s3.uploadThreads", defaultValue = "10")
+  private int s3UploadThreads;
+
   @Parameter(property = "slimfast.s3.downloadThreads", defaultValue = "10")
   private int s3DownloadThreads;
 

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/S3Factory.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/S3Factory.java
@@ -20,7 +20,7 @@ public class S3Factory {
         .withClientConfiguration(
             new ClientConfiguration()
                 .withConnectionTimeout(2_000)
-                .withRequestTimeout(5_000)
+                .withSocketTimeout(5_000)
                 .withMaxErrorRetry(5)
         )
         .build();

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadConfiguration.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadConfiguration.java
@@ -10,6 +10,7 @@ public class UploadConfiguration {
   private final String s3SecretKey;
   private final Path outputFile;
   private final boolean allowUnresolvedSnapshots;
+  private final int uploadThreads;
 
   public UploadConfiguration(Path prefix,
                              String s3Bucket,
@@ -17,7 +18,8 @@ public class UploadConfiguration {
                              String s3AccessKey,
                              String s3SecretKey,
                              Path outputFile,
-                             boolean allowUnresolvedSnapshots) {
+                             boolean allowUnresolvedSnapshots,
+                             int uploadThreads) {
     this.prefix = prefix;
     this.s3Bucket = s3Bucket;
     this.s3ArtifactRoot = s3ArtifactRoot;
@@ -25,6 +27,7 @@ public class UploadConfiguration {
     this.s3SecretKey = s3SecretKey;
     this.outputFile = outputFile;
     this.allowUnresolvedSnapshots = allowUnresolvedSnapshots;
+    this.uploadThreads = uploadThreads;
   }
 
   public Path getPrefix() {
@@ -53,5 +56,9 @@ public class UploadConfiguration {
 
   public boolean isAllowUnresolvedSnapshots() {
     return allowUnresolvedSnapshots;
+  }
+
+  public int getUploadThreads() {
+    return uploadThreads;
   }
 }

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadJarsMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadJarsMojo.java
@@ -131,7 +131,8 @@ public class UploadJarsMojo extends AbstractMojo {
         s3AccessKey,
         s3SecretKey,
         Paths.get(outputFile),
-        allowUnresolvedSnapshots
+        allowUnresolvedSnapshots,
+        s3UploadThreads
     );
   }
 


### PR DESCRIPTION
I recently tried to build something that depends on `com.amazonaws:aws-java-sdk-bundle` and had issues with SlimFast. When uploading that dependency JAR to S3, I got this error:
```
[ERROR] Failed to execute goal com.hubspot.maven.plugins:slimfast-plugin:0.19:upload (upload-dependency-jars) on project hbase-tasks-jobs: Error uploading file /usr/share/hubspot/build/.m2/repository/com/amazonaws/aws-java-sdk-bundle/1.11.628/aws-java-sdk-bundle-1.11.628.jar: Unable to execute HTTP request: Request did not complete before the request timeout configuration. Connection or outbound has been closed -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.hubspot.maven.plugins:slimfast-plugin:0.19:upload (upload-dependency-jars) on project hbase-tasks-jobs: Error uploading file /usr/share/hubspot/build/.m2/repository/com/amazonaws/aws-java-sdk-bundle/1.11.628/aws-java-sdk-bundle-1.11.628.jar
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
.....
Caused by: org.apache.maven.plugin.MojoFailureException: Error uploading file /usr/share/hubspot/build/.m2/repository/com/amazonaws/aws-java-sdk-bundle/1.11.628/aws-java-sdk-bundle-1.11.628.jar
    at com.hubspot.maven.plugins.slimfast.DefaultFileUploader.doUpload (DefaultFileUploader.java:35)
    at com.hubspot.maven.plugins.slimfast.BaseFileUploader.upload (BaseFileUploader.java:57)
    at com.hubspot.slimfast.LoggingJarUploader.upload (LoggingJarUploader.java:42)
    at com.hubspot.maven.plugins.slimfast.UploadJarsMojo$1.call (UploadJarsMojo.java:95)
....
Caused by: com.amazonaws.SdkClientException: Unable to execute HTTP request: Request did not complete before the request timeout configuration.
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleRetryableException (AmazonHttpClient.java:1163)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper (AmazonHttpClient.java:1109)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute (AmazonHttpClient.java:758)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer (AmazonHttpClient.java:732)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute (AmazonHttpClient.java:714)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500 (AmazonHttpClient.java:674)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute (AmazonHttpClient.java:656)
    at com.amazonaws.http.AmazonHttpClient.execute (AmazonHttpClient.java:520)
    at com.amazonaws.services.s3.AmazonS3Client.invoke (AmazonS3Client.java:4705)
    at com.amazonaws.services.s3.AmazonS3Client.invoke (AmazonS3Client.java:4652)
    at com.amazonaws.services.s3.AmazonS3Client.putObject (AmazonS3Client.java:1807)
    at com.amazonaws.services.s3.AmazonS3Client.putObject (AmazonS3Client.java:1658)
    at com.hubspot.maven.plugins.slimfast.DefaultFileUploader.doUpload (DefaultFileUploader.java:32)
    at com.hubspot.maven.plugins.slimfast.BaseFileUploader.upload (BaseFileUploader.java:57)
    at com.hubspot.slimfast.LoggingJarUploader.upload (LoggingJarUploader.java:42)
    at com.hubspot.maven.plugins.slimfast.UploadJarsMojo$1.call (UploadJarsMojo.java:95)
.....
Caused by: com.amazonaws.http.exception.HttpRequestTimeoutException: Request did not complete before the request timeout configuration.
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest (AmazonHttpClient.java:1299)
.....
    at com.amazonaws.services.s3.AmazonS3Client.putObject (AmazonS3Client.java:1807)
    at com.amazonaws.services.s3.AmazonS3Client.putObject (AmazonS3Client.java:1658)
    at com.hubspot.maven.plugins.slimfast.DefaultFileUploader.doUpload (DefaultFileUploader.java:32)
    at com.hubspot.maven.plugins.slimfast.BaseFileUploader.upload (BaseFileUploader.java:57)
    at com.hubspot.slimfast.LoggingJarUploader.upload (LoggingJarUploader.java:42)
    at com.hubspot.maven.plugins.slimfast.UploadJarsMojo$1.call (UploadJarsMojo.java:95)
.....
Caused by: javax.net.ssl.SSLException: Connection or outbound has been closed
    at sun.security.ssl.Alert.createSSLException (Alert.java:127)
    at sun.security.ssl.TransportContext.fatal (TransportContext.java:320)
    at sun.security.ssl.TransportContext.fatal (TransportContext.java:263)
    at sun.security.ssl.TransportContext.fatal (TransportContext.java:258)
    at sun.security.ssl.SSLSocketImpl$AppOutputStream.write (SSLSocketImpl.java:988)
......   
Caused by: java.net.SocketException: Connection or outbound has been closed
    at sun.security.ssl.SSLSocketOutputRecord.deliver (SSLSocketOutputRecord.java:267)
    at sun.security.ssl.SSLSocketImpl$AppOutputStream.write (SSLSocketImpl.java:983)
    at org.apache.http.impl.io.SessionOutputBufferImpl.streamWrite (SessionOutputBufferImpl.java:124)
    at org.apache.http.impl.io.SessionOutputBufferImpl.flushBuffer (SessionOutputBufferImpl.java:136)
    at org.apache.http.impl.io.SessionOutputBufferImpl.write (SessionOutputBufferImpl.java:167)
    at org.apache.http.impl.io.ContentLengthOutputStream.write (ContentLengthOutputStream.java:113)
.......
``` 

The `aws-java-sdk-bundle-1.11.628.jar` file is particularly large, 134 MiB, and I think that's the problem. SlimFast sets a 5 second request timeout and this big PUT request is probably exceeding that. Amazon supports multipart uploads for just this reason. This change uses Amazon's TransferManager to automatically split the upload into multiple HTTP requests. The TransferManager will automatically shut down its thread pool when garbage collected.

I've tested this on an internal HubSpot build by setting `dep.plugin.slimfast-plugin.version` and it did successfully upload `aws-java-sdk-bundle-1.11.628.jar`.