### PR TITLE
Allow S3 uploads using Default AWS credential chain. 

### DIFF
--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DownloadJarsMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DownloadJarsMojo.java
@@ -28,10 +28,10 @@ public class DownloadJarsMojo extends AbstractMojo {
   @Parameter(property = "slimfast.fileDownloader", alias = "fileDownloader", defaultValue = "com.hubspot.maven.plugins.slimfast.DefaultFileDownloader")
   private String fileDownloaderType;
 
-  @Parameter(property = "slimfast.s3.accessKey", defaultValue = "${s3.access.key}", required = true)
+  @Parameter(property = "slimfast.s3.accessKey", defaultValue = "${s3.access.key}")
   private String s3AccessKey;
 
-  @Parameter(property = "slimfast.s3.secretKey", defaultValue = "${s3.secret.key}", required = true)
+  @Parameter(property = "slimfast.s3.secretKey", defaultValue = "${s3.secret.key}")
   private String s3SecretKey;
 
   @Parameter(property = "slimfast.s3.downloadThreads", defaultValue = "10")

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/S3Factory.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/S3Factory.java
@@ -4,6 +4,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
@@ -14,7 +15,12 @@ public class S3Factory {
   }
 
   public static AmazonS3 create(String accessKey, String secretKey) {
-    AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+    AWSCredentials credentials;
+    if (accessKey != null && secretKey != null) {
+      credentials = new BasicAWSCredentials(accessKey, secretKey);
+    } else {
+      credentials = DefaultAWSCredentialsProviderChain.getInstance().getCredentials();
+    }
     return AmazonS3ClientBuilder.standard()
         .withCredentials(new AWSStaticCredentialsProvider(credentials))
         .withClientConfiguration(

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadJarsMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadJarsMojo.java
@@ -46,10 +46,10 @@ public class UploadJarsMojo extends AbstractMojo {
   @Parameter(property = "slimfast.s3.artifactPrefix", defaultValue = "${s3.artifact.root}", required = true)
   private String s3ArtifactRoot;
 
-  @Parameter(property = "slimfast.s3.accessKey", defaultValue = "${s3.access.key}", required = true)
+  @Parameter(property = "slimfast.s3.accessKey", defaultValue = "${s3.access.key}")
   private String s3AccessKey;
 
-  @Parameter(property = "slimfast.s3.secretKey", defaultValue = "${s3.secret.key}", required = true)
+  @Parameter(property = "slimfast.s3.secretKey", defaultValue = "${s3.secret.key}")
   private String s3SecretKey;
 
   @Parameter(property = "slimfast.s3.uploadThreads", defaultValue = "10")


### PR DESCRIPTION
 This removes the requirement to supply explicit access and secret keys and allows the use of implicit role-based permissions

If you could merge and make a new release, that would be excellent