### PR TITLE
Create new mojos to split up prepare, upload steps

### DIFF
--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/BaseFileUploader.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/BaseFileUploader.java
@@ -11,7 +11,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
-public abstract class BaseFileUploader implements FileUploader {
+public abstract class BaseFileUploader implements FileUploader, FromManifestUploader {
   private Set<S3Artifact> s3Artifacts;
   private Path prefix;
   private Path outputFile;
@@ -36,8 +36,19 @@ public abstract class BaseFileUploader implements FileUploader {
 
   @Override
   public void upload(UploadConfiguration config, LocalArtifact artifact) throws MojoExecutionException, MojoFailureException {
-    String file = artifact.getTargetPath().toString();
-    Path localPath = artifact.getLocalPath();
+    upload(config, artifact.getTargetPath(), artifact.getLocalPath());
+  }
+
+  @Override
+  public void uploadFromManifest(UploadConfiguration config, PreparedArtifact artifact) throws MojoExecutionException, MojoFailureException {
+    Path targetPath = Paths.get(artifact.getTargetPath());
+    Path localPath = Paths.get(artifact.getLocalPath());
+
+    upload(config, targetPath, localPath);
+  }
+
+  private void upload(UploadConfiguration config, Path targetPath, Path localPath) throws MojoExecutionException, MojoFailureException {
+    String file = targetPath.toString();
     boolean isUnresolvedSnapshot = file.toUpperCase().endsWith("-SNAPSHOT.JAR");
 
     final String s3Key;
@@ -56,8 +67,8 @@ public abstract class BaseFileUploader implements FileUploader {
 
     doUpload(config.getS3Bucket(), s3Key, localPath);
 
-    String targetPath = prefix.resolve(artifact.getTargetPath()).toString();
-    s3Artifacts.add(new S3Artifact(config.getS3Bucket(), s3Key, targetPath, FileHelper.md5(localPath), FileHelper.size(localPath)));
+    String targetPathAsString = targetPath.toString();
+    s3Artifacts.add(new S3Artifact(config.getS3Bucket(), s3Key, targetPathAsString, FileHelper.md5(localPath), FileHelper.size(localPath)));
   }
 
   @Override

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/BaseFileUploader.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/BaseFileUploader.java
@@ -67,7 +67,7 @@ public abstract class BaseFileUploader implements FileUploader, FromManifestUplo
 
     doUpload(config.getS3Bucket(), s3Key, localPath);
 
-    String targetPathAsString = targetPath.toString();
+    String targetPathAsString = prefix.resolve(targetPath).toString();
     s3Artifacts.add(new S3Artifact(config.getS3Bucket(), s3Key, targetPathAsString, FileHelper.md5(localPath), FileHelper.size(localPath)));
   }
 

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/FromManifestUploader.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/FromManifestUploader.java
@@ -1,0 +1,11 @@
+package com.hubspot.maven.plugins.slimfast;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+
+public interface FromManifestUploader {
+    void init(UploadConfiguration config, Log log) throws MojoExecutionException, MojoFailureException;
+    void uploadFromManifest(UploadConfiguration config, PreparedArtifact artifact) throws MojoExecutionException, MojoFailureException;
+    void destroy() throws MojoExecutionException, MojoFailureException;
+}

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/PreparedArtifact.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/PreparedArtifact.java
@@ -1,0 +1,19 @@
+package com.hubspot.maven.plugins.slimfast;
+
+public class PreparedArtifact {
+    private final String localPath;
+    private final String targetPath;
+
+    public PreparedArtifact(String localPath, String targetPath) {
+        this.localPath = localPath;
+        this.targetPath = targetPath;
+    }
+
+    public String getLocalPath() {
+        return localPath;
+    }
+
+    public String getTargetPath() {
+        return targetPath;
+    }
+}

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/PreparedArtifactWrapper.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/PreparedArtifactWrapper.java
@@ -1,0 +1,21 @@
+package com.hubspot.maven.plugins.slimfast;
+
+import java.util.Set;
+
+public class PreparedArtifactWrapper {
+    private final String prefix;
+    private final Set<PreparedArtifact> artifacts;
+
+    public PreparedArtifactWrapper(String prefix, Set<PreparedArtifact> artifacts) {
+        this.prefix = prefix;
+        this.artifacts = artifacts;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public Set<PreparedArtifact> getArtifacts() {
+        return artifacts;
+    }
+}

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadFromManifestMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadFromManifestMojo.java
@@ -1,0 +1,146 @@
+package com.hubspot.maven.plugins.slimfast;
+
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+@Mojo(name = "upload-from-manifest", threadSafe = true, requiresDependencyResolution = ResolutionScope.RUNTIME)
+public class UploadFromManifestMojo extends AbstractMojo {
+    private static final String DEFAULT_UPLOADER = "com.hubspot.maven.plugins.slimfast.DefaultFileUploader";
+    private static final String DRY_RUN_UPLOADER = "com.hubspot.maven.plugins.slimfast.DryRunFileUploader";
+
+    @Parameter(property = "slimfast.fromManifestFileUploader", alias = "fileUploader", defaultValue = DEFAULT_UPLOADER)
+    private String fileUploaderType;
+
+    @Parameter(property = "slimfast.s3.accessKey", defaultValue = "${s3.access.key}", required = true)
+    private String s3AccessKey;
+
+    @Parameter(property = "slimfast.s3.secretKey", defaultValue = "${s3.secret.key}", required = true)
+    private String s3SecretKey;
+
+    @Parameter(property = "slimfast.manifestFile", defaultValue = "${project.build.directory}/slimfast-local.json")
+    private String manifestFile;
+
+    @Parameter(property = "slimfast.dryRun", defaultValue = "false")
+    private boolean dryRun;
+
+    @Parameter(property = "slimfast.s3.bucket", defaultValue = "${s3.bucket}", required = true)
+    private String s3Bucket;
+
+    @Parameter(property = "slimfast.s3.artifactPrefix", defaultValue = "${s3.artifact.root}", required = true)
+    private String s3ArtifactRoot;
+
+    @Parameter(property = "slimfast.s3.uploadThreads", defaultValue = "10")
+    private int s3UploadThreads;
+
+    @Parameter(property = "slimfast.plugin.skip", defaultValue = "false")
+    private boolean skip;
+
+    @Parameter(property = "slimfast.outputFile", defaultValue = "${project.build.directory}/slimfast.json")
+    private String outputFile;
+
+    @Parameter(property = "slimfast.allowUnresolvedSnapshots", defaultValue = "false")
+    private boolean allowUnresolvedSnapshots;
+
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        final PreparedArtifactWrapper preparedArtifactWrapper;
+        try {
+            preparedArtifactWrapper = JsonHelper.readPreparedArtifactsFromJson(Paths.get(manifestFile).toFile());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to read manifest file", e);
+        }
+
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("slimfast-upload").setDaemon(true).build();
+        ExecutorService executor = Executors.newFixedThreadPool(s3UploadThreads, threadFactory);
+        Path prefix = Paths.get(preparedArtifactWrapper.getPrefix());
+        final UploadConfiguration configuration = buildConfiguration(prefix);
+        FromManifestUploader fileUploader = instantiateFileUploader();
+        fileUploader.init(configuration, getLog());
+
+        List<Future<?>> futures = new ArrayList<>();
+        for (final PreparedArtifact artifact : preparedArtifactWrapper.getArtifacts()) {
+            futures.add(executor.submit(() -> {
+                fileUploader.uploadFromManifest(configuration, artifact);
+                return null;
+            }));
+        }
+
+        executor.shutdown();
+        waitForUploadsToFinish(executor, futures);
+        fileUploader.destroy();
+    }
+
+    private UploadConfiguration buildConfiguration(Path prefix) {
+        return new UploadConfiguration(
+                prefix,
+                s3Bucket,
+                s3ArtifactRoot,
+                s3AccessKey,
+                s3SecretKey,
+                Paths.get(outputFile),
+                allowUnresolvedSnapshots
+        );
+    }
+
+    private void waitForUploadsToFinish(ExecutorService executor, List<Future<?>> futures) throws MojoExecutionException, MojoFailureException {
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.MINUTES)) {
+                getLog().error("Took more than 5 minutes to upload files, quitting");
+                throw new MojoExecutionException("Took more than 5 minutes to upload files");
+            }
+
+            for (Future<?> future : futures) {
+                future.get();
+
+            }
+        } catch (InterruptedException e) {
+            throw new MojoExecutionException("Interrupted", e);
+        } catch (ExecutionException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), MojoExecutionException.class);
+            Throwables.propagateIfInstanceOf(e.getCause(), MojoFailureException.class);
+            throw new MojoExecutionException("Unexpected exception", e.getCause());
+        }
+    }
+
+    private FromManifestUploader instantiateFileUploader() throws MojoExecutionException {
+        final String resolvedFileUploaderType;
+        if (dryRun) {
+            if (DEFAULT_UPLOADER.equals(fileUploaderType)) {
+                resolvedFileUploaderType = DRY_RUN_UPLOADER;
+            } else {
+                throw new MojoExecutionException("May not specify custom fileUploader when using the dryRun flag");
+            }
+        } else {
+            resolvedFileUploaderType = fileUploaderType;
+        }
+
+        try {
+            return (FromManifestUploader) Class.forName(resolvedFileUploaderType).newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new MojoExecutionException("Unable to find file uploader implementation", e);
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new MojoExecutionException("Unable to instantiate file uploader", e);
+        } catch (ClassCastException e) {
+            throw new MojoExecutionException("Must implement FileUploader interface", e);
+        }
+    }
+}

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadFromManifestMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadFromManifestMojo.java
@@ -140,7 +140,7 @@ public class UploadFromManifestMojo extends AbstractMojo {
         } catch (InstantiationException | IllegalAccessException e) {
             throw new MojoExecutionException("Unable to instantiate file uploader", e);
         } catch (ClassCastException e) {
-            throw new MojoExecutionException("Must implement FileUploader interface", e);
+            throw new MojoExecutionException("Must implement FromManifestUploader interface", e);
         }
     }
 }

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/WriteManifestMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/WriteManifestMojo.java
@@ -1,0 +1,61 @@
+package com.hubspot.maven.plugins.slimfast;
+
+import org.apache.maven.configuration.BeanConfigurator;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
+@Mojo(name = "write-manifest", threadSafe = true, requiresDependencyResolution = ResolutionScope.RUNTIME)
+public class WriteManifestMojo extends AbstractMojo {
+    @Component
+    private BeanConfigurator beanConfigurator;
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Parameter(property = "slimfast.plugin.skip", defaultValue = "false")
+    private boolean skip;
+
+    @Parameter(property = "slimfast.outputFile", defaultValue = "${project.build.directory}/slimfast-local.json")
+    private String outputFile;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping plugin execution");
+            return;
+        }
+
+        LocalArtifactWrapper artifactWrapper = ArtifactHelper.getArtifactPaths(beanConfigurator, project);
+        Path outputFile = Paths.get(this.outputFile);
+        FileHelper.ensureDirectoryExists(outputFile.getParent());
+        Path prefix = artifactWrapper.getPrefix();
+
+        Set<PreparedArtifact> s3Artifacts = new HashSet<>();
+        for (LocalArtifact artifact : artifactWrapper.getArtifacts()) {
+            s3Artifacts.add(prepareArtifact(artifact));
+        }
+
+        PreparedArtifactWrapper preparedArtifactWrapper = new PreparedArtifactWrapper(prefix.toString(), s3Artifacts);
+        try {
+            JsonHelper.writeArtifactsToJson(outputFile.toFile(), preparedArtifactWrapper);
+        } catch (IOException e) {
+            throw new MojoFailureException("Failed writing manifest file to disk", e);
+        }
+    }
+
+    private PreparedArtifact prepareArtifact(LocalArtifact artifact) {
+        return new PreparedArtifact(artifact.getLocalPath().toString(), artifact.getTargetPath().toString());
+    }
+}


### PR DESCRIPTION
Ran into an issue where a consequence of splitting up the package and deploy steps resulted in the the files listed in the classpath field in the manifest file not being the same ones as were used in the Slimfast file (which ultimately became the files on disk). This manifested in NoClassDefFound errors for files in certain jars.

This allows writing a manifest file to disk (intended to be during the package phase) that will list exactly what was used during the build, and then a second mojo (for the deploy phase) that will read from that manifest file, then do the upload and write out the normal Slimfast manifest file for later distribution.

@jaredstehler @ggs5427 @jhaber 