### PR TITLE
Respect `skip` configuration property

### DIFF
--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadFromManifestMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/UploadFromManifestMojo.java
@@ -62,6 +62,11 @@ public class UploadFromManifestMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping plugin execution");
+            return;
+        }
+
         final PreparedArtifactWrapper preparedArtifactWrapper;
         try {
             preparedArtifactWrapper = JsonHelper.readPreparedArtifactsFromJson(Paths.get(manifestFile).toFile());


### PR DESCRIPTION
This mojo was intended to respect the `skip` parameter, but it wasn't doing so.