### PR TITLE
use aws default credential provider if no access keys provided

### DIFF
--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/BaseUploadMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/BaseUploadMojo.java
@@ -29,18 +29,10 @@ public abstract class BaseUploadMojo extends AbstractMojo {
   )
   private String fileUploaderType;
 
-  @Parameter(
-    property = "slimfast.s3.accessKey",
-    defaultValue = "${s3.access.key}",
-    required = true
-  )
+  @Parameter(property = "slimfast.s3.accessKey", defaultValue = "${s3.access.key}")
   private String s3AccessKey;
 
-  @Parameter(
-    property = "slimfast.s3.secretKey",
-    defaultValue = "${s3.secret.key}",
-    required = true
-  )
+  @Parameter(property = "slimfast.s3.secretKey", defaultValue = "${s3.secret.key}")
   private String s3SecretKey;
 
   @Parameter(property = "slimfast.s3.region", defaultValue = "${s3.region}")
@@ -101,8 +93,8 @@ public abstract class BaseUploadMojo extends AbstractMojo {
 
   protected UploadConfiguration buildConfiguration(Path prefix) {
     S3Configuration s3Configuration = new S3Configuration(
-      s3AccessKey,
-      s3SecretKey,
+      Optional.ofNullable(s3AccessKey),
+      Optional.ofNullable(s3SecretKey),
       Optional.ofNullable(s3Region).map(Region::of),
       Optional.of(20.0), // aws-sdk default is 10.0
       Optional.empty() // aws-sdk default is 8mb

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DownloadJarsMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DownloadJarsMojo.java
@@ -22,18 +22,10 @@ public class DownloadJarsMojo extends AbstractMojo {
   )
   private String fileDownloaderType;
 
-  @Parameter(
-    property = "slimfast.s3.accessKey",
-    defaultValue = "${s3.access.key}",
-    required = true
-  )
+  @Parameter(property = "slimfast.s3.accessKey", defaultValue = "${s3.access.key}")
   private String s3AccessKey;
 
-  @Parameter(
-    property = "slimfast.s3.secretKey",
-    defaultValue = "${s3.secret.key}",
-    required = true
-  )
+  @Parameter(property = "slimfast.s3.secretKey", defaultValue = "${s3.secret.key}")
   private String s3SecretKey;
 
   @Parameter(property = "slimfast.s3.region", defaultValue = "${s3.region}")
@@ -79,8 +71,8 @@ public class DownloadJarsMojo extends AbstractMojo {
 
   private DownloadConfiguration buildConfiguration(String prefix) {
     S3Configuration s3Configuration = new S3Configuration(
-      s3AccessKey,
-      s3SecretKey,
+      Optional.ofNullable(s3AccessKey),
+      Optional.ofNullable(s3SecretKey),
       Optional.ofNullable(s3Region).map(Region::of),
       Optional.of(20.0), // aws-sdk default is 10.0
       Optional.empty() // aws-sdk default is 8mb

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/S3Configuration.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/S3Configuration.java
@@ -5,16 +5,16 @@ import software.amazon.awssdk.regions.Region;
 
 public class S3Configuration {
 
-  private final String accessKey;
-  private final String secretKey;
+  private final Optional<String> accessKey;
+  private final Optional<String> secretKey;
 
   private final Optional<Region> region;
   private final Optional<Double> targetThroughputGbps;
   private final Optional<Long> minPartSizeBytes;
 
   public S3Configuration(
-    String accessKey,
-    String secretKey,
+    Optional<String> accessKey,
+    Optional<String> secretKey,
     Optional<Region> region,
     Optional<Double> targetThroughputGbps,
     Optional<Long> minPartSizeBytes
@@ -26,11 +26,11 @@ public class S3Configuration {
     this.minPartSizeBytes = minPartSizeBytes;
   }
 
-  public String getAccessKey() {
+  public Optional<String> getAccessKey() {
     return accessKey;
   }
 
-  public String getSecretKey() {
+  public Optional<String> getSecretKey() {
     return secretKey;
   }
 


### PR DESCRIPTION
Uses the default credentials provider when no s3 access key or secret are provided in configuration:

AWS credentials provider chain that looks for credentials in this order:
1. Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`
1. Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
1. Web Identity Token credentials from system properties or environment variables
1. Credential profiles file at the default location (`~/.aws/ credentials`) shared by all AWS SDKs and the AWS CLI
1. Credentials delivered through the Amazon EC2 container service if `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and security manager has permission to access the variable,
1. Instance profile credentials delivered through the Amazon EC2 metadata service

Adapted from https://github.com/HubSpot/SlimFast/pull/23
