### PR TITLE
update param name from s3.region to aws.region

### DIFF
--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/BaseUploadMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/BaseUploadMojo.java
@@ -35,8 +35,8 @@ public abstract class BaseUploadMojo extends AbstractMojo {
   @Parameter(property = "slimfast.s3.secretKey", defaultValue = "${s3.secret.key}")
   private String s3SecretKey;
 
-  @Parameter(property = "slimfast.s3.region", defaultValue = "${s3.region}")
-  private String s3Region;
+  @Parameter(property = "slimfast.aws.region", defaultValue = "${aws.region}")
+  private String awsRegion;
 
   @Parameter(property = "slimfast.dryRun", defaultValue = "false")
   private boolean dryRun;
@@ -95,7 +95,7 @@ public abstract class BaseUploadMojo extends AbstractMojo {
     S3Configuration s3Configuration = new S3Configuration(
       Optional.ofNullable(s3AccessKey),
       Optional.ofNullable(s3SecretKey),
-      Optional.ofNullable(s3Region).map(Region::of),
+      Optional.ofNullable(awsRegion).map(Region::of),
       Optional.of(20.0), // aws-sdk default is 10.0
       Optional.empty() // aws-sdk default is 8mb
     );

--- a/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DownloadJarsMojo.java
+++ b/slimfast-plugin/src/main/java/com/hubspot/maven/plugins/slimfast/DownloadJarsMojo.java
@@ -28,11 +28,8 @@ public class DownloadJarsMojo extends AbstractMojo {
   @Parameter(property = "slimfast.s3.secretKey", defaultValue = "${s3.secret.key}")
   private String s3SecretKey;
 
-  @Parameter(property = "slimfast.s3.region", defaultValue = "${s3.region}")
-  private String s3Region;
-
-  @Parameter(property = "slimfast.s3.downloadThreads", defaultValue = "10")
-  private int s3DownloadThreads;
+  @Parameter(property = "slimfast.aws.region", defaultValue = "${aws.region}")
+  private String awsRegion;
 
   @Parameter(
     property = "slimfast.cacheDirectory",
@@ -73,7 +70,7 @@ public class DownloadJarsMojo extends AbstractMojo {
     S3Configuration s3Configuration = new S3Configuration(
       Optional.ofNullable(s3AccessKey),
       Optional.ofNullable(s3SecretKey),
-      Optional.ofNullable(s3Region).map(Region::of),
+      Optional.ofNullable(awsRegion).map(Region::of),
       Optional.of(20.0), // aws-sdk default is 10.0
       Optional.empty() // aws-sdk default is 8mb
     );


### PR DESCRIPTION
Updates region parameter to match our naming conventions:

* `s3Region` -> `awsRegion`
* `slimfast.s3.region` -> `slimfast.aws.region`
* `${s3.region}` -> `${aws.region}`

